### PR TITLE
Updated code so that it is Py3 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ dist: trusty
 
 python:
     - "2.7"
+    - "3.6"
 
 env:
     matrix:

--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -15,6 +15,6 @@
    limitations under the License.
 """
 
-from pycompssapp import PyCOMPSsApp
-from localapp import LocalApp
-from workflowapp import WorkflowApp
+from apps.pycompssapp import PyCOMPSsApp
+from apps.localapp import LocalApp
+from apps.workflowapp import WorkflowApp

--- a/apps/jsonapp.py
+++ b/apps/jsonapp.py
@@ -23,6 +23,7 @@ import json
 
 from apps.workflowapp import WorkflowApp
 from basic_modules.metadata import Metadata
+from utils import logger
 
 
 class JSONApp(WorkflowApp):  # pylint: disable=too-few-public-methods
@@ -77,7 +78,7 @@ class JSONApp(WorkflowApp):  # pylint: disable=too-few-public-methods
         >>> # writes /path/to/results.json
         """
 
-        print "0) Unpack information from JSON"
+        logger.info("0) Unpack information from JSON")
         input_ids, arguments, output_files = self._read_config(
             config_path)
 
@@ -105,7 +106,7 @@ class JSONApp(WorkflowApp):  # pylint: disable=too-few-public-methods
             tool_class, input_files, input_metadata,
             output_files, arguments)
 
-        print "4) Pack information to JSON"
+        logger.info("4) Pack information to JSON")
         return self._write_results(
             input_files, input_metadata,
             output_files, output_metadata,

--- a/basic_modules/app.py
+++ b/basic_modules/app.py
@@ -18,6 +18,7 @@
 
 from __future__ import print_function
 from basic_modules.metadata import Metadata  # pylint: disable=unused-import
+from utils import logger
 
 
 # -----------------------------------------------------------------------------
@@ -98,10 +99,10 @@ class App(object):  # pylint: disable=too-few-public-methods
         >>> app.launch(Tool, {"input": <input_file>}, {})
         """
 
-        print("1) Instantiate and configure Tool")
+        logger.info("1) Instantiate and configure Tool")
         tool_instance = self._instantiate_tool(tool_class, configuration)
 
-        print("2) Run Tool")
+        logger.info("2) Run Tool")
         input_files, input_metadata = self._pre_run(tool_instance,
                                                     input_files,
                                                     input_metadata)
@@ -114,7 +115,7 @@ class App(object):  # pylint: disable=too-few-public-methods
                                                        output_files,
                                                        output_metadata)
 
-        print("Output_files: ", output_files)
+        logger.info("Output_files: ", output_files)
         return output_files, output_metadata
 
     def _instantiate_tool(self, tool_class, configuration):  # pylint: disable=no-self-use


### PR DESCRIPTION
With COMPSs 2.3 they are now using the 18.04 Ubuntu release that has python 3 as the base version of python. There have also been updates to the version of python supported by pyCOMPSs.

There are a few minor changes that are required so that the Tool API is compatible with python 3. These are also backwards compatible with python 2 and have run pytest with the ChIP-seq pipeline in mg-process-fastq to ensure that it works.